### PR TITLE
Add getlocalhashps RPC call to expose local hashrate

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -44,7 +44,6 @@
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockWeight = 0;
 uint64_t nMiningTimeStart = 0;
-uint64_t nHashesPerSec = 0;
 uint64_t nHashesDone = 0;
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)

--- a/src/miner.h
+++ b/src/miner.h
@@ -19,6 +19,9 @@ class CBlockIndex;
 class CChainParams;
 class CScript;
 
+// current local hashes/sec
+uint64_t nHashesPerSec = 0;
+
 namespace Consensus { struct Params; };
 
 static const bool DEFAULT_PRINTPRIORITY = false;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -104,6 +104,23 @@ static UniValue getnetworkhashps(const JSONRPCRequest& request)
     return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].get_int() : 120, !request.params[1].isNull() ? request.params[1].get_int() : -1);
 }
 
+static UniValue getlocalhashps(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+            "getlocalhashps\n"
+            "\nReturns the hashes per second of this node's miner."
+            "\nResult:\n"
+            "x             (numeric) Hashes per second\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getlocalhashps", "")
+            + HelpExampleRpc("getlocalhashps", "")
+        );
+
+    // return the value from miner.h
+    return nHashesPerSec;
+}
+
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
 {
     static const int nInnerLoopCount = 0x10000;
@@ -200,6 +217,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             "  \"currentblockweight\": nnn, (numeric) The last block weight\n"
             "  \"currentblocktx\": nnn,     (numeric) The last block transaction\n"
             "  \"difficulty\": xxx.xxxxx    (numeric) The current difficulty\n"
+            "  \"localhashps\": nnn,        (numeric) The local node's hashes per second\n"
             "  \"networkhashps\": nnn,      (numeric) The network hashes per second\n"
             "  \"pooledtx\": n              (numeric) The size of the mempool\n"
             "  \"chain\": \"xxxx\",           (string) current network name as defined in BIP70 (main, test, regtest)\n"
@@ -218,6 +236,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
     obj.pushKV("currentblockweight", (uint64_t)nLastBlockWeight);
     obj.pushKV("currentblocktx",   (uint64_t)nLastBlockTx);
     obj.pushKV("difficulty",       (double)GetDifficulty(chainActive.Tip()));
+    obj.pushKV("localhashps",      getlocalhashps(request));
     obj.pushKV("networkhashps",    getnetworkhashps(request));
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain",            Params().NetworkIDString());
@@ -1025,6 +1044,7 @@ static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
     { "mining",             "getnetworkhashps",       &getnetworkhashps,       {"nblocks","height"} },
+    { "mining",             "getlocalhashps",         &getlocalhashps,         {} },
     { "mining",             "getmininginfo",          &getmininginfo,          {} },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  {"txid","dummy","fee_delta"} },
     { "mining",             "getblocktemplate",       &getblocktemplate,       {"template_request"} },


### PR DESCRIPTION
I've added the RPC call 'getlocalhashps', which allows a CPU miner to know
their current hashrate. Prints out as an integer, like

```
./src/bsha3-cli getlocalhashps
1807692
```

It'll also show in 'getmininginfo':

```
./src/bsha3-cli getmininginfo
{
  "blocks": 6084,
  "currentblockweight": 4000,
  "currentblocktx": 0,
  "difficulty": 18.73298317075785,
  "localhashps": 1727272,
  "networkhashps": 275870950.3436443,
  "pooledtx": 0,
  "chain": "main",
  "warnings": ""
}
```

I didn't update the rpc documentation because... I couldn't find any?
bitcoin doesn't have an rpc doc page i guess lol
It does show when you run 'bsha3-cli help' though