### PR TITLE
Clean up includes from miner.cpp/wallet.cpp

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -25,7 +25,6 @@
 #include <util.h>
 #include <utilmoneystr.h>
 #include <validationinterface.h>
-
 #include <wallet/wallet.h>
 
 #include <algorithm>
@@ -33,8 +32,6 @@
 #include <utility>
 
 #include <boost/thread.hpp>
-
-#include <wallet/wallet.cpp>
 
 // Unconfirmed transactions in the memory pool often depend on other
 // transactions in the memory pool. When we select transactions from the

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -45,6 +45,7 @@ uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockWeight = 0;
 uint64_t nMiningTimeStart = 0;
 uint64_t nHashesDone = 0;
+uint64_t nHashesPerSec = 0;
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {

--- a/src/miner.h
+++ b/src/miner.h
@@ -20,7 +20,7 @@ class CChainParams;
 class CScript;
 
 // current local hashes/sec
-uint64_t nHashesPerSec = 0;
+extern uint64_t nHashesPerSec;
 
 namespace Consensus { struct Params; };
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -37,9 +37,6 @@
 
 static const size_t OUTPUT_GROUP_MAX_ENTRIES = 10;
 
-static CCriticalSection cs_wallets;
-static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
-
 bool AddWallet(const std::shared_ptr<CWallet>& wallet)
 {
     LOCK(cs_wallets);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -39,6 +39,9 @@ bool HasWallets();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
 std::shared_ptr<CWallet> GetWallet(const std::string& name);
 
+static CCriticalSection cs_wallets;
+static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
+
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default


### PR DESCRIPTION
I found that I broke the build on ubuntu with my last commit. I changed nHashesPerSec to be declared extern in miner.h to fix this.

I also removed the #include <wallet/wallet.cpp> from miner.cpp, and moved a couple declarations into wallet.h, this fixes the #11 where tests weren't building.