### PR TITLE
fs: Change minimum directory sizes for chain data

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -23,9 +23,9 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-constexpr uint64_t BLOCK_CHAIN_SIZE = 220;
+constexpr uint64_t BLOCK_CHAIN_SIZE = 32;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
-static const uint64_t CHAIN_STATE_SIZE = 3;
+static const uint64_t CHAIN_STATE_SIZE = 1;
 /* Total required space (in GB) depending on user choice (prune, not prune) */
 static uint64_t requiredSpace;
 


### PR DESCRIPTION
Change minimum directory size to to 32GB and 1GB from 200+GB and 3GB (for datadir and chainstate respectively)