### PR TITLE
contrib: Add windows bat files for easy cli usage

### DIFF
--- a/contrib/win/README.md
+++ b/contrib/win/README.md
@@ -1,0 +1,8 @@
+### Win (Windows Utilities) ###
+
+These `.bat` files should be included with CLI releases for Windows.
+This is to improve ease-of-use by not requiring that `cmd` must first be opened.
+
+- `start-daemon.bat` - Starts `bsha3d` via `bsha3d`
+- `stop-daemon.bat` - Stops `bsha3d` via  `bsha3-cli stop`
+- `cli.bat` - Opens the user to the `help` command output, and remains at prompt

--- a/contrib/win/cli.bat
+++ b/contrib/win/cli.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+TITLE [BSHA3] To use, run: bsha3-cli help
+bsha3-cli.exe help
+cmd /k

--- a/contrib/win/start-daemon.bat
+++ b/contrib/win/start-daemon.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+TITLE [BSHA3] Daemon Process (Syncs and Validates)
+bsha3d.exe

--- a/contrib/win/stop-daemon.bat
+++ b/contrib/win/stop-daemon.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+TITLE [BSHA3] Shutting down Daemon Process...
+bsha3-cli.exe stop


### PR DESCRIPTION
These `.bat` files should be included with CLI releases for Windows.
This is to improve ease-of-use by not requiring that `cmd` must first be opened.
 - `start-daemon.bat` - Starts `bsha3d` via `bsha3d`
- `stop-daemon.bat` - Stops `bsha3d` via  `bsha3-cli stop`
- `cli.bat` - Opens the user to the `help` command output, and remains at prompt