### PR TITLE
Attempt 2 at fixing tests build error

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -25,7 +25,6 @@
 #include <util.h>
 #include <utilmoneystr.h>
 #include <validationinterface.h>
-
 #include <wallet/wallet.h>
 
 #include <algorithm>
@@ -33,8 +32,6 @@
 #include <utility>
 
 #include <boost/thread.hpp>
-
-#include <wallet/wallet.cpp>
 
 // Unconfirmed transactions in the memory pool often depend on other
 // transactions in the memory pool. When we select transactions from the

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -37,8 +37,8 @@
 
 static const size_t OUTPUT_GROUP_MAX_ENTRIES = 10;
 
-static CCriticalSection cs_wallets;
-static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
+CCriticalSection cs_wallets;
+std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
 
 bool AddWallet(const std::shared_ptr<CWallet>& wallet)
 {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -39,6 +39,9 @@ bool HasWallets();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
 std::shared_ptr<CWallet> GetWallet(const std::string& name);
 
+extern CCriticalSection cs_wallets;
+extern std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
+
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default


### PR DESCRIPTION
My previous change to wallet.cpp/h was to move the variable vpwallets
and its lock cs_wallets from the cpp file to the header file, then
remove the #include <wallet/wallet.cpp>... however this caused a
deadlocking issue in miner.cpp and it turns out I broke mining lol.

This change seems to fix it. I declared those cs_wallets and
vpwallets variables as extern instead of static and now the mining
threads do indeed create blocks.

This reverts commit ad9817d579007c81f228a45e7bacc61611d80b99.